### PR TITLE
 Add parameter `$encodeValue` to `Cookie` constructor and `Cookie::withRawValue()` method 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 
 ## 1.1.1 under development
 
-- no changes in this release.
+- Add #27: Add the parameter `$encodeValue` to the `Cookie` constructor and the `Cookie::withRawValue()` method 
+  that creates a cookie copy with a new value that will not be encoded (vjik)
 
 
 ## 1.1.0 May 05, 2021

--- a/README.md
+++ b/README.md
@@ -140,6 +140,13 @@ $middleware = new \Yiisoft\Cookies\CookieMiddleware(
 $response = $middleware->process($request, $handler);
 ```
 
+Create cookie with raw value that will not be encoded:
+
+```php
+$cookie = (new \Yiisoft\Cookies\Cookie('cookieName'))
+    ->withRawValue('ebaKUq90PhiHck_MR7st-E1SxhbYWiTsLo82mCTbNuAh7rgflx5LVsYfJJseyQCrODuVcJkTSYhm1WKte-l5lQ==')
+```
+
 See [Yii guide to cookies](https://github.com/yiisoft/docs/blob/master/guide/en/runtime/cookies.md) for more info.
 
 ## Testing

--- a/tests/CookieTest.php
+++ b/tests/CookieTest.php
@@ -292,6 +292,14 @@ final class CookieTest extends TestCase
         $this->assertEquals(Cookie::SAME_SITE_LAX, $cookie->getSameSite());
     }
 
+    public function testRawValue(): void
+    {
+        $cookie = (new Cookie('test'))->withRawValue('Q==');
+
+        $this->assertSame('Q==', $cookie->getValue());
+        $this->assertSame('test=Q==; Path=/; Secure; HttpOnly; SameSite=Lax', (string)$cookie);
+    }
+
     public function testImmutability(): void
     {
         $expires = new DateTime();
@@ -310,6 +318,7 @@ final class CookieTest extends TestCase
         $this->assertNotSame($original, $original->withSameSite(Cookie::SAME_SITE_LAX));
         $this->assertNotSame($original, $original->withSecure(true));
         $this->assertNotSame($original, $original->withValue('value'));
+        $this->assertNotSame($original, $original->withRawValue('value'));
         $this->assertNotSame($original, $original->expire());
         $this->assertNotSame($original, $original->expireWhenBrowserIsClosed());
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | #26 
