### PR TITLE
Allow to use PSR-20 clock interface to get current time into `Cookie`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Chg #69: Change PHP constraint in `composer.json` to `~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0`
   (@vjik)
+- Enh #72: Allow to use PSR-20 clock interface to get current time into `Cookie` (@vjik)
 
 ## 1.2.2 April 05, 2024
 

--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,7 @@
         "httpsoft/http-message": "^1.1.6",
         "maglnet/composer-require-checker": "^3.8 || ^4.2",
         "phpunit/phpunit": "^9.6.22",
+        "psr/clock": "^1.0",
         "rector/rector": "^2.0.11",
         "roave/infection-static-analysis-plugin": "^1.18",
         "spatie/phpunit-watcher": "^1.23.6",

--- a/tests/CookieTest.php
+++ b/tests/CookieTest.php
@@ -12,6 +12,7 @@ use HttpSoft\Message\Response;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Yiisoft\Cookies\Cookie;
+use Yiisoft\Cookies\Tests\Support\StaticClock;
 
 final class CookieTest extends TestCase
 {
@@ -190,7 +191,8 @@ final class CookieTest extends TestCase
 
     public function fromCookieStringDataProvider(): array
     {
-        $maxAgeDate = new DateTimeImmutable('+60 minutes');
+        $clock = new StaticClock(new DateTimeImmutable('2019/12/7 10:05 UTC+0'));
+        $maxAgeDate = $clock->now()->modify('+60 minutes');
         $expireDate = new DateTimeImmutable('2012/12/7 10:00 UTC+0');
 
         return [
@@ -206,7 +208,9 @@ final class CookieTest extends TestCase
                     '/test',
                     true,
                     true,
-                    Cookie::SAME_SITE_STRICT
+                    Cookie::SAME_SITE_STRICT,
+                    true,
+                    $clock
                 ),
             ],
             [
@@ -220,7 +224,9 @@ final class CookieTest extends TestCase
                     null,
                     false,
                     false,
-                    null
+                    null,
+                    true,
+                    $clock
                 ),
             ],
             [
@@ -228,12 +234,14 @@ final class CookieTest extends TestCase
                 new Cookie(
                     'sessionId',
                     'e8bb43229de9',
-                    new DateTimeImmutable(),
+                    $clock->now(),
                     'foo.example.com=test',
                     null,
                     false,
                     false,
-                    null
+                    null,
+                    true,
+                    $clock
                 ),
             ],
         ];
@@ -244,8 +252,11 @@ final class CookieTest extends TestCase
      */
     public function testFromCookieString(string $setCookieString, Cookie $cookie): void
     {
-        $cookie2 = Cookie::fromCookieString($setCookieString);
-        $this->assertSame((string)$cookie, (string)$cookie2);
+        $cookie2 = Cookie::fromCookieString(
+            $setCookieString,
+            new StaticClock(new DateTimeImmutable('2019/12/7 10:05 UTC+0')),
+        );
+        $this->assertSame((string) $cookie, (string) $cookie2);
     }
 
     public function testFromCookieStringWithEmptyString(): void

--- a/tests/Support/StaticClock.php
+++ b/tests/Support/StaticClock.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Cookies\Tests\Support;
+
+use DateTimeImmutable;
+use Psr\Clock\ClockInterface;
+
+final class StaticClock implements ClockInterface
+{
+    private DateTimeImmutable $now;
+
+    public function __construct(DateTimeImmutable $now)
+    {
+        $this->now = $now;
+    }
+
+    public function now(): DateTimeImmutable
+    {
+        return $this->now;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
Fix #55 
